### PR TITLE
feat: Endpoint Hash RTAs March

### DIFF
--- a/cortado/rtas/amsi_bypass_via_unbacked_memory.py
+++ b/cortado/rtas/amsi_bypass_via_unbacked_memory.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="cbb29b1d-e0ef-4c00-a2ca-0f5277deb3a3",
+    name="amsi_bypass_via_unbacked_memory",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="06516087-9305-482b-af9a-92f4386d2f19", name="AMSI Bypass via Unbacked Memory")
+    ],
+    techniques=['T1562', 'T1562.001'],
+    sample_hash="aa31279da8b6c8dbefe9d3d6c423f3f785fd13ab8539839c73d13e9580ebe22c",
+)

--- a/cortado/rtas/attempt_to_mount_a_remote_webdav_share.py
+++ b/cortado/rtas/attempt_to_mount_a_remote_webdav_share.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="0eeb9564-8765-4c29-a2f5-f7670e1cd669",
+    name="attempt_to_mount_a_remote_webdav_share",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="0a364281-5edc-4f75-a839-48b150cec3f2", name="Attempt to Mount a Remote WebDav Share")
+    ],
+    techniques=['T1204', 'T1204.002', 'T1021', 'T1021.002'],
+    sample_hash="bbf1699eeb08269b7d7a3982be6fa207f3d767ba9e48c406db102a552db716eb",
+)

--- a/cortado/rtas/execution_from_suspicious_stack_trailing_bytes.py
+++ b/cortado/rtas/execution_from_suspicious_stack_trailing_bytes.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="8be64c37-dfc0-4ee4-a4e3-63c42ed33bca",
+    name="execution_from_suspicious_stack_trailing_bytes",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="0a26ccb6-41b9-418d-9314-854aadcb1fba", name="Execution from Suspicious Stack Trailing Bytes")
+    ],
+    techniques=[],
+    sample_hash="ad6e942d541570bedea0a2560ecd8ad7783593eef510af7f2f48a8a4d00aa674",
+)

--- a/cortado/rtas/execution_via_obfuscated_powershell_script.py
+++ b/cortado/rtas/execution_via_obfuscated_powershell_script.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="64d4640c-3c0f-4e5f-b8b1-e910b8a5d152",
+    name="execution_via_obfuscated_powershell_script",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="ce95fc52-051e-4409-9c99-f2daf3e6e609", name="Execution via Obfuscated PowerShell Script")
+    ],
+    techniques=['T1059', 'T1059.001'],
+    sample_hash="47ae6d232dee297bf10ee6b88ee560801c3e7b0504485e254e4bc69b611ba3d8",
+)

--- a/cortado/rtas/firewall_policy_changed_by_a_suspicious_process.py
+++ b/cortado/rtas/firewall_policy_changed_by_a_suspicious_process.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="49360b18-d88a-470c-b551-2851773797a6",
+    name="firewall_policy_changed_by_a_suspicious_process",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="bf072c39-90bc-4b1b-9c78-1d8a9bd6f0e1", name="Firewall Policy Changed by a Suspicious Process")
+    ],
+    techniques=['T1562', 'T1562.001'],
+    sample_hash="bdf06c7902c1d0b705be7415aad80836686d4d44482ced0bb2d4c7670c501255",
+)

--- a/cortado/rtas/image_hollow_from_unusual_stack.py
+++ b/cortado/rtas/image_hollow_from_unusual_stack.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="e8b32a35-de6f-4f22-a132-6e233f7eaf8d",
+    name="image_hollow_from_unusual_stack",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="446e61bf-8370-45df-88ab-7b213ee653db", name="Image Hollow from Unusual Stack")
+    ],
+    techniques=['T1055'],
+    sample_hash="966a6c9fd83512c580dfc9f8cf666361ba6f7491d296e707a29c4780e5825f3f",
+)

--- a/cortado/rtas/internet_activity_from_suspicious_unbacked_memory.py
+++ b/cortado/rtas/internet_activity_from_suspicious_unbacked_memory.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="e55a01e6-5a5c-4934-91aa-7dad9e93c59c",
+    name="internet_activity_from_suspicious_unbacked_memory",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="7dca0e22-0e3f-4ed0-ad28-eff5617adf75", name="Internet Activity from Suspicious Unbacked Memory")
+    ],
+    techniques=['T1055'],
+    sample_hash="17bc5b41b35d894b37224e5daa66e2c7326e10a8309e299af122c6602afc953e",
+)

--- a/cortado/rtas/microsoft_common_language_runtime_loaded_from_suspicious_memory.py
+++ b/cortado/rtas/microsoft_common_language_runtime_loaded_from_suspicious_memory.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="44f50c16-742b-427a-aee7-6d812f908814",
+    name="microsoft_common_language_runtime_loaded_from_suspicious_memory",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="ad2c6fcc-89d3-4939-85d9-d7114d6bbf14", name="Microsoft Common Language Runtime Loaded from Suspicious Memory")
+    ],
+    techniques=['T1055'],
+    sample_hash="44788f535787ccc40ce79b30e4191e48986c2d40025cc0d55c32668b52acb3fa",
+)

--- a/cortado/rtas/netsupport_execution_form_unusual_path.py
+++ b/cortado/rtas/netsupport_execution_form_unusual_path.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="9c5b7e6f-9053-44a3-ab28-36409845bdec",
+    name="netsupport_execution_form_unusual_path",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="f36c407e-27c1-4682-a322-73dd0cddf29d", name="NetSupport Execution form unusual Path")
+    ],
+    techniques=['T1219'],
+    sample_hash="8967c17e9f455d2af6b0c65817851bc03b1389bfaa92f566728de2d2a562f58a",
+)

--- a/cortado/rtas/network_activity_from_a_stomped_module.py
+++ b/cortado/rtas/network_activity_from_a_stomped_module.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="66d7626a-3ae6-464b-ba20-446ce2b556dd",
+    name="network_activity_from_a_stomped_module",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="4388a77b-4ddf-4e15-8314-ecf96c77807a", name="Network Activity from a Stomped Module")
+    ],
+    techniques=['T1055'],
+    sample_hash="966a6c9fd83512c580dfc9f8cf666361ba6f7491d296e707a29c4780e5825f3f",
+)

--- a/cortado/rtas/network_connect_api_from_unbacked_memory.py
+++ b/cortado/rtas/network_connect_api_from_unbacked_memory.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="6c264182-eaef-4776-aa52-4846fc0e79ff",
+    name="network_connect_api_from_unbacked_memory",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="720e0265-03bc-4cb7-9116-7fad5ea9cdfc", name="Network Connect API from Unbacked Memory")
+    ],
+    techniques=['T1055'],
+    sample_hash="eec61b37516a902f999d664590ae8538794f2bbf5f454be52c837cf52760dbfa",
+)

--- a/cortado/rtas/network_module_loaded_from_a_backed_rwx_memory.py
+++ b/cortado/rtas/network_module_loaded_from_a_backed_rwx_memory.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="340f4c29-1fa6-42b0-846b-c56da0040498",
+    name="network_module_loaded_from_a_backed_rwx_memory",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="a1d00ee9-64d6-440a-8940-fd2d940152a6", name="Network Module Loaded from a Backed RWX Memory")
+    ],
+    techniques=['T1055'],
+    sample_hash="adfdb5d77b78750b46681a4792ffa6b30ba6665cad6127d61110ada5a7e139fb",
+)

--- a/cortado/rtas/parallel_ntdll_loaded_from_unbacked_memory.py
+++ b/cortado/rtas/parallel_ntdll_loaded_from_unbacked_memory.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="40944110-6966-4e9c-aef0-d7fe1093b87b",
+    name="parallel_ntdll_loaded_from_unbacked_memory",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="69267bb2-e2d9-4621-9bf6-064ac885e49c", name="Parallel NTDLL Loaded from Unbacked Memory")
+    ],
+    techniques=['T1055'],
+    sample_hash="81e4808bcd2b11a4fd3b23668882628bcbdce55c62009daa4b97b15e421e6d13",
+)

--- a/cortado/rtas/parent_process_pid_spoofing.py
+++ b/cortado/rtas/parent_process_pid_spoofing.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="4a39696b-43c2-4703-b942-5e8e6cbd1840",
+    name="parent_process_pid_spoofing",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="816ba7e7-519a-4f85-be2a-bacd6ccde57f", name="Parent Process PID Spoofing")
+    ],
+    techniques=['T1134', 'T1134.004'],
+    sample_hash="80e5cb11ae2512da3b7be501b469d6fc1a69a2017a143b9897023da9e366325f",
+)

--- a/cortado/rtas/payload_decoded_via_certutil.py
+++ b/cortado/rtas/payload_decoded_via_certutil.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="950aa5b4-c99f-44ad-872b-f66ab1ddc17c",
+    name="payload_decoded_via_certutil",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="dbc72ac5-a004-45de-916d-e8aac82c4789", name="Payload Decoded via CertUtil")
+    ],
+    techniques=['T1027', 'T1140'],
+    sample_hash="24f65e496692a64157011ed08648a853312526299131e4f819376889ff94876d",
+)

--- a/cortado/rtas/potential_crypto_mining_activity.py
+++ b/cortado/rtas/potential_crypto_mining_activity.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="bdc606e1-a136-447d-9e55-de60a89dffea",
+    name="potential_crypto_mining_activity",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="fe082539-a528-4453-ac19-34d57f2f7730", name="Potential Crypto Mining Activity")
+    ],
+    techniques=['T1496'],
+    sample_hash="af94ddf7c35b9d9f016a5a4b232b43e071d59c6beb1560ba76df20df7b49ca4c",
+)

--- a/cortado/rtas/potential_dll_hollowing_with_transactional_ntfs.py
+++ b/cortado/rtas/potential_dll_hollowing_with_transactional_ntfs.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="52751955-55a7-4409-bc16-4bd26cf118ed",
+    name="potential_dll_hollowing_with_transactional_ntfs",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="7f61cf66-1363-4b2a-8f82-73cc2bd46b17", name="Potential DLL Hollowing with Transactional NTFS")
+    ],
+    techniques=['T1055'],
+    sample_hash="e7fa4f8df8fa95adffb3b0a08d091dd26830c17ef4cceed95f33ec087fbcf0ce",
+)

--- a/cortado/rtas/potential_evasion_via_invalid_code_signature.py
+++ b/cortado/rtas/potential_evasion_via_invalid_code_signature.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="34587ca9-3adb-42e6-948c-d1f81dc12680",
+    name="potential_evasion_via_invalid_code_signature",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="f3f769b9-0695-49ed-ab6e-c8f199a7d2c8", name="Potential Evasion via Invalid Code Signature")
+    ],
+    techniques=['T1055', 'T1036'],
+    sample_hash="fb68f4812303beb08bb62f4b54bde01c0c11220ec1aab78d71f76f42ada86cdf",
+)

--- a/cortado/rtas/potential_injection_via_asynchronous_procedure_call.py
+++ b/cortado/rtas/potential_injection_via_asynchronous_procedure_call.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="009e8ec8-6a9e-4449-9fa5-8961907b636e",
+    name="potential_injection_via_asynchronous_procedure_call",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="2316b571-731d-4745-97ac-4fd6922d32df", name="Potential Injection via Asynchronous Procedure Call")
+    ],
+    techniques=['T1055'],
+    sample_hash="94827a4ab543972eacee8e610ec94d8469de43fe8dc0302015f1c587b158025d",
+)

--- a/cortado/rtas/potential_injection_via_pyinstaller_executable.py
+++ b/cortado/rtas/potential_injection_via_pyinstaller_executable.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="cf5e28a1-0c35-4be1-87ba-381dcdbb2d8b",
+    name="potential_injection_via_pyinstaller_executable",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="deb48ee3-8ce0-4ff7-a30b-041c5db024bb", name="Potential Injection via PyInstaller Executable")
+    ],
+    techniques=['T1055'],
+    sample_hash="c081174ab9326b2a9e552dd1b96017b51dd5212a8621d97144b697002baa2ef4",
+)

--- a/cortado/rtas/potential_operation_via_direct_syscall.py
+++ b/cortado/rtas/potential_operation_via_direct_syscall.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="6d1885f8-b82f-48ff-b621-50b507ced8e8",
+    name="potential_operation_via_direct_syscall",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="30106950-2383-49cd-b462-ed55be29b10b", name="Potential Operation via Direct Syscall")
+    ],
+    techniques=['T1055'],
+    sample_hash="6c4a8bd310ce4f1146d84ca455a560fd082e7d22d8b8c772cef5ce89f68e3191",
+)

--- a/cortado/rtas/potential_remote_code_injection.py
+++ b/cortado/rtas/potential_remote_code_injection.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="195ab730-3bab-4738-b3b9-36d29cc541d2",
+    name="potential_remote_code_injection",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="f1d05929-4271-4d39-9cae-05eab6d4efca", name="Potential Remote Code Injection")
+    ],
+    techniques=['T1055'],
+    sample_hash="67f264aef12ee76e84254428afc9e489162b57f2f019dec7ec85c421d616a7ad",
+)

--- a/cortado/rtas/potential_shellcode_injection_via_clr.py
+++ b/cortado/rtas/potential_shellcode_injection_via_clr.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="08717def-f6f4-4ff9-8091-4f13411c308d",
+    name="potential_shellcode_injection_via_clr",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="1370f164-1809-4668-ad6c-dbf5bd278120", name="Potential Shellcode Injection via CLR")
+    ],
+    techniques=['T1055'],
+    sample_hash="0478f76edf55a95129c2dc410864c96e662827e14cda5d63f31456bb66122e42",
+)

--- a/cortado/rtas/potential_windows_script_evasion_via_sleep.py
+++ b/cortado/rtas/potential_windows_script_evasion_via_sleep.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="1728887a-c3f0-42d0-b590-b175341caab7",
+    name="potential_windows_script_evasion_via_sleep",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="30203e6b-0f9e-410a-a34d-6fe037866cca", name="Potential Windows Script Evasion via Sleep")
+    ],
+    techniques=['T1059', 'T1059.005', 'T1059.007'],
+    sample_hash="5a049c1a40bd41636bd3602019154e333fa83db601f862c7f370fb06b21db561",
+)

--- a/cortado/rtas/process_anti-debug_via_memory_patching.py
+++ b/cortado/rtas/process_anti-debug_via_memory_patching.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="5110c22c-f37c-4097-a78d-eb70a448ae37",
+    name="process_anti-debug_via_memory_patching",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="4db10fd9-e219-4566-9388-8e9a0b7ac7a9", name="Process Anti-Debug via Memory Patching")
+    ],
+    techniques=['T1574'],
+    sample_hash="b663833709691d3f95e434a750129c56564f6463932a66c91c0bb73564072d26",
+)

--- a/cortado/rtas/process_creation_from_a_stomped_module.py
+++ b/cortado/rtas/process_creation_from_a_stomped_module.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="09e70b8f-cfa0-4277-b9db-23381a2cf1ee",
+    name="process_creation_from_a_stomped_module",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="b444173e-ef79-4e76-b329-f0926aa249ee", name="Process Creation from a Stomped Module")
+    ],
+    techniques=['T1055'],
+    sample_hash="633c016f6f7f3eab1995d7fe36f60721a042fd78496cc43516cc3a2047ab0fcf",
+)

--- a/cortado/rtas/process_creation_from_an_unusual_wmi_client.py
+++ b/cortado/rtas/process_creation_from_an_unusual_wmi_client.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="c065d4a4-3128-449d-91e4-23adeb6d789c",
+    name="process_creation_from_an_unusual_wmi_client",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="2cbb7988-4fea-4242-a0c0-25f4dd068946", name="Process Creation from an Unusual WMI Client")
+    ],
+    techniques=["T1047"],
+    sample_hash="fea10c485839f80cc78106c2ef1d4a3ef70a5a0c208586be219a070bca061d6c",
+)

--- a/cortado/rtas/process_creation_via_rop_gadgets.py
+++ b/cortado/rtas/process_creation_via_rop_gadgets.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="1badc49a-e6eb-4d15-9582-60e8ab40b8dc",
+    name="process_creation_via_rop_gadgets",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="4cd250a2-82a0-463b-adda-5256cee422ce", name="Process Creation via ROP Gadgets")
+    ],
+    techniques=['T1055'],
+    sample_hash="6c4a8bd310ce4f1146d84ca455a560fd082e7d22d8b8c772cef5ce89f68e3191",
+)

--- a/cortado/rtas/process_memory_write_to_a_non_child_process.py
+++ b/cortado/rtas/process_memory_write_to_a_non_child_process.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="93f0485e-9fc8-4ac2-9bee-e2604a7b0bfa",
+    name="process_memory_write_to_a_non_child_process",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="fa2e2435-d285-485e-9890-dff92cb78ab7", name="Process Memory Write to a Non Child Process")
+    ],
+    techniques=['T1055'],
+    sample_hash="67f264aef12ee76e84254428afc9e489162b57f2f019dec7ec85c421d616a7ad",
+)

--- a/cortado/rtas/remote_memory_write_to_trusted_target_process.py
+++ b/cortado/rtas/remote_memory_write_to_trusted_target_process.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="36167273-a4c6-4c58-a608-71610e2690f9",
+    name="remote_memory_write_to_trusted_target_process",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="5c6c166c-a894-4263-918a-c7632014a486", name="Remote Memory Write to Trusted Target Process")
+    ],
+    techniques=['T1055'],
+    sample_hash="0301f0dc2a049a1967afa9e1c842a276436b3d370eef4ae163a1ef84c37181da",
+)

--- a/cortado/rtas/remote_process_injection_via_mapping.py
+++ b/cortado/rtas/remote_process_injection_via_mapping.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="d470e747-0ff5-496d-9998-79730d69af02",
+    name="remote_process_injection_via_mapping",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="95c534ee-1a49-4a35-bea2-2853f2737a17", name="Remote Process Injection via Mapping")
+    ],
+    techniques=['T1055'],
+    sample_hash="ac381e891cda88d95c3402a58a256a52f1ff4e4fd0f4803f4d4ddd43691dd81f",
+)

--- a/cortado/rtas/remote_process_injection_via_python.py
+++ b/cortado/rtas/remote_process_injection_via_python.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="95e761e4-5161-43b4-b34d-95e846a0c94c",
+    name="remote_process_injection_via_python",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="634dcd98-0656-48a8-bd41-5fa025b6c812", name="Remote Process Injection via Python")
+    ],
+    techniques=['T1055'],
+    sample_hash="d8e3240539b9d124c081506af59cf87d47b89139e423894063ac9389697b49a2",
+)

--- a/cortado/rtas/remote_process_manipulation_by_suspicious_process.py
+++ b/cortado/rtas/remote_process_manipulation_by_suspicious_process.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="cfe1d663-20b3-4a1b-a98e-9ce83d5e9f7c",
+    name="remote_process_manipulation_by_suspicious_process",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="902f471c-27b4-4e78-b344-be46c6cfb72b", name="Remote Process Manipulation by Suspicious Process")
+    ],
+    techniques=['T1055'],
+    sample_hash="4628d075894ec8212dfe33f263873efc3cfb012889015810eb60453a0a1e8889",
+)

--- a/cortado/rtas/remote_thread_context_manipulation.py
+++ b/cortado/rtas/remote_thread_context_manipulation.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="f16c1b45-2d5c-499b-a117-2db5794c4ce9",
+    name="remote_thread_context_manipulation",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="c456266f-e920-4acb-9b32-711fa7b94ca5", name="Remote Thread Context Manipulation")
+    ],
+    techniques=['T1055'],
+    sample_hash="bdfb4f30c9fb3a9ff5858926086443518095fced463371da099b9ad977d53c83",
+)

--- a/cortado/rtas/rundll32_or_regsvr32_loaded_a_dll_from_unbacked_memory.py
+++ b/cortado/rtas/rundll32_or_regsvr32_loaded_a_dll_from_unbacked_memory.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="ee850735-544f-4d59-bd8b-f355033144f0",
+    name="rundll32_or_regsvr32_loaded_a_dll_from_unbacked_memory",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="226df8a0-6ef8-4965-91b4-7ce64078c206", name="Rundll32 or Regsvr32 Loaded a DLL from Unbacked Memory")
+    ],
+    techniques=['T1055', 'T1218', 'T1218.011', 'T1218.010'],
+    sample_hash="09bc480835114679224d2e98980a85e2f67ab99a682b3a27f45f9ee520ea3b6b",
+)

--- a/cortado/rtas/scheduled_task_creation_by_an_unusual_process.py
+++ b/cortado/rtas/scheduled_task_creation_by_an_unusual_process.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="67e1e8ad-b03a-4a54-a557-1a0f7d1df09b",
+    name="scheduled_task_creation_by_an_unusual_process",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="cb5fdbe3-84fa-4277-a967-1ffc0e8d3d25", name="Scheduled Task Creation by an Unusual Process")
+    ],
+    techniques=['T1053', 'T1053.005'],
+    sample_hash="6c2e0ad04040327910085d9ca58be3fbe423e5f15c1fe982c4ec41b48cb39c71",
+)

--- a/cortado/rtas/script_execution_from_webdav.py
+++ b/cortado/rtas/script_execution_from_webdav.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="5e59211e-50c0-4ed6-8b78-ad58c6fa6f65",
+    name="script_execution_from_webdav",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="4bdd5646-f7b2-4e1d-962d-fd0f591f8f87", name="Script Execution from WebDav")
+    ],
+    techniques=['T1204', 'T1204.002', 'T1021', 'T1021.002'],
+    sample_hash="eff23a6a6760f74a437cd5cca64bdf97d929b0c3bd50e7ba66a2c5e7a183bf87",
+)

--- a/cortado/rtas/self_service_persistence_by_an_unsigned_process.py
+++ b/cortado/rtas/self_service_persistence_by_an_unsigned_process.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="6e56fef6-e76b-489e-a234-3b02144006aa",
+    name="self_service_persistence_by_an_unsigned_process",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="e5ad5d97-da99-4371-9611-b6dfa8e55e30", name="Self Service Persistence by an Unsigned Process")
+    ],
+    techniques=['T1543', 'T1543.003'],
+    sample_hash="79dc900d0bfac9749b5ddb5d237b3d384769104ad22eeec29a30752263593f67",
+)

--- a/cortado/rtas/shellcode_execution_via_a_callback_function.py
+++ b/cortado/rtas/shellcode_execution_via_a_callback_function.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="5c536d4c-0e38-47a9-8258-5b6ef4095c7a",
+    name="shellcode_execution_via_a_callback_function",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="976d1f98-59ab-452c-858b-cb1596355564", name="Shellcode Execution via a CallBack Function")
+    ],
+    techniques=['T1055'],
+    sample_hash="eeb85ca851a8864c3835c7ae34a29e897524a5de4da362957093ae08549568ec",
+)

--- a/cortado/rtas/shellcode_execution_via_python_script.py
+++ b/cortado/rtas/shellcode_execution_via_python_script.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="9898d2a6-f4d9-45f1-92d5-53bc6fb2015b",
+    name="shellcode_execution_via_python_script",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="1d0a1b39-a29e-4370-a712-546ed047f5f5", name="Shellcode Execution via Python Script")
+    ],
+    techniques=['T1055'],
+    sample_hash="d8e3240539b9d124c081506af59cf87d47b89139e423894063ac9389697b49a2",
+)

--- a/cortado/rtas/shellcode_injection_via_powershell.py
+++ b/cortado/rtas/shellcode_injection_via_powershell.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="62e16851-d0e9-464d-91aa-d016cfbfed38",
+    name="shellcode_injection_via_powershell",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="98fffa16-53e1-4db9-9126-2d0441cac417", name="Shellcode Injection via PowerShell")
+    ],
+    techniques=['T1055', 'T1059', 'T1059.001'],
+    sample_hash="47ae6d232dee297bf10ee6b88ee560801c3e7b0504485e254e4bc69b611ba3d8",
+)

--- a/cortado/rtas/shellcode_injection_with_parent_as_provenance.py
+++ b/cortado/rtas/shellcode_injection_with_parent_as_provenance.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="da9c98ec-dba0-4efd-8534-039367b46147",
+    name="shellcode_injection_with_parent_as_provenance",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="631df705-0636-4f83-8374-24d61307735e", name="Shellcode Injection with Parent as Provenance")
+    ],
+    techniques=['T1055'],
+    sample_hash="2fe6a7ae63c878bd84d7b829349b309e7c84194ddbb6a779816f5b84cd8ad45d",
+)

--- a/cortado/rtas/startup_persistence_from_backed_rwx_memory.py
+++ b/cortado/rtas/startup_persistence_from_backed_rwx_memory.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="fbcd275f-aeba-4297-a25a-cbe8fe596399",
+    name="startup_persistence_from_backed_rwx_memory",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="15c48f2d-e461-40a9-accd-090a0863ea10", name="Startup Persistence from Backed RWX Memory")
+    ],
+    techniques=['T1547', 'T1547.001'],
+    sample_hash="a30c4fc8b11cb71e7b91b955a1ac756daf4444bbf04d79d4f292953599e2abfd",
+)

--- a/cortado/rtas/suspicious_api_call_from_a_powershell_script.py
+++ b/cortado/rtas/suspicious_api_call_from_a_powershell_script.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="b03b9e9b-28f9-43db-92f8-d50677da1eb9",
+    name="suspicious_api_call_from_a_powershell_script",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="6ad0c702-ddf0-4631-ac43-37eeea444ee6", name="Suspicious API Call from a PowerShell Script")
+    ],
+    techniques=['T1059', 'T1059.001'],
+    sample_hash="da4c2a0697dac3f01667714903224d07e21777e57002f1a37c508ec1f489f80d",
+)

--- a/cortado/rtas/suspicious_api_from_an_unsigned_service_dll.py
+++ b/cortado/rtas/suspicious_api_from_an_unsigned_service_dll.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="7e5e28fc-b112-47f0-92d2-0a5c54c5cf03",
+    name="suspicious_api_from_an_unsigned_service_dll",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="1a16b12e-6719-4f58-8835-84880092f3a0", name="Suspicious API from an Unsigned Service DLL")
+    ],
+    techniques=['T1543', 'T1543.003'],
+    sample_hash="caaff622a1f527db9d3d05f83ae343351bd4c0214ca2de705397154c48435480",
+)

--- a/cortado/rtas/suspicious_communication_via_mail_protocol.py
+++ b/cortado/rtas/suspicious_communication_via_mail_protocol.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="adc67195-dd7a-41f5-a929-6ea25559a26a",
+    name="suspicious_communication_via_mail_protocol",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="0898f7c9-f667-4db1-a1ce-ddbf61a32361", name="Suspicious Communication via Mail Protocol")
+    ],
+    techniques=['T1071', 'T1071.003', 'T1204', 'T1204.002'],
+    sample_hash="afbf51cbceee0bb274325a6bbdeb87bcaadf086f26b97a4715a0345d2d20252e",
+)

--- a/cortado/rtas/suspicious_directshow_devices_enumeration.py
+++ b/cortado/rtas/suspicious_directshow_devices_enumeration.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="7caa250c-87c2-43de-aa87-1fc85481fd0f",
+    name="suspicious_directshow_devices_enumeration",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="d6699c83-fb2f-4029-8fb4-0f628f131a22", name="Suspicious DirectShow Devices Enumeration")
+    ],
+    techniques=['T1123', 'T1125', 'T1112'],
+    sample_hash="518d9aeaf075a297467fbd6962f4a04f7f256680f9b506b4e4b51b67c185b365",
+)

--- a/cortado/rtas/suspicious_dns_lookup_by_remote_utilities_rmm.py
+++ b/cortado/rtas/suspicious_dns_lookup_by_remote_utilities_rmm.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="4297b3f2-936c-4166-b77a-1063d778280a",
+    name="suspicious_dns_lookup_by_remote_utilities_rmm",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="ff6e6c37-8048-4b94-8c83-bb9919081caf", name="Suspicious DNS Lookup by Remote Utilities RMM")
+    ],
+    techniques=['T1219'],
+    sample_hash="5ee0c66e6c00f98587b262e43d8e922a1f49c2490aaa543cd837a01e7e42a0f3",
+)

--- a/cortado/rtas/suspicious_executable_heap_allocation.py
+++ b/cortado/rtas/suspicious_executable_heap_allocation.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="677ae39b-b3b8-4331-9d5d-87265d6ceeb4",
+    name="suspicious_executable_heap_allocation",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="4d21b212-1046-41fc-98f1-b4c175594fb2", name="Suspicious Executable Heap Allocation")
+    ],
+    techniques=['T1055'],
+    sample_hash="db5e626fd6a1c8735888aeec339f3c8cc6150ff55afd39591ac7ebc16e341b6f",
+)

--- a/cortado/rtas/suspicious_executable_memory_mapping.py
+++ b/cortado/rtas/suspicious_executable_memory_mapping.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="5466965c-e2e4-43d4-94bd-5605c7fc1802",
+    name="suspicious_executable_memory_mapping",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="20a1f655-498a-4a73-8793-9f7ed14b9601", name="Suspicious Executable Memory Mapping")
+    ],
+    techniques=['T1055'],
+    sample_hash="8cea17eff24495134a3e6389071ed05d067057fff645ed688af65209cd913890",
+)

--- a/cortado/rtas/suspicious_execution_via_windows_services.py
+++ b/cortado/rtas/suspicious_execution_via_windows_services.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="8058bc1b-83c5-4990-83f7-2bfcde5c3aa4",
+    name="suspicious_execution_via_windows_services",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="84595d39-df78-49d6-a999-48792482b255", name="Suspicious Execution via Windows Services")
+    ],
+    techniques=['T1543', 'T1543.003'],
+    sample_hash="79dc900d0bfac9749b5ddb5d237b3d384769104ad22eeec29a30752263593f67",
+)

--- a/cortado/rtas/suspicious_memory_protection_change_via_virtualprotect.py
+++ b/cortado/rtas/suspicious_memory_protection_change_via_virtualprotect.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="e9fb015e-5f26-4c39-a8ef-710dcefdd548",
+    name="suspicious_memory_protection_change_via_virtualprotect",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="8fcf2b81-8322-423b-a1b4-6bba722f599a", name="Suspicious Memory Protection Change via VirtualProtect")
+    ],
+    techniques=['T1055'],
+    sample_hash="24ef9c8f66fb72058ce87b39819849c41facfb5c2ac8ac903ebf4277580fc7b4",
+)

--- a/cortado/rtas/suspicious_memory_size_protection_via_virtualprotect.py
+++ b/cortado/rtas/suspicious_memory_size_protection_via_virtualprotect.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="495e340a-f237-4de9-9265-714dd7c0742d",
+    name="suspicious_memory_size_protection_via_virtualprotect",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="c771303c-a200-4df3-bb76-3e5f87a18438", name="Suspicious Memory Size Protection via VirtualProtect")
+    ],
+    techniques=['T1055'],
+    sample_hash="7ee450ffaf282d0d9982c64d5e45d80d6a5ab8d5d1fd9038066e1c36d8292776",
+)

--- a/cortado/rtas/suspicious_memory_write_to_a_remote_process.py
+++ b/cortado/rtas/suspicious_memory_write_to_a_remote_process.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="a0a332e8-1c40-441f-9afa-32f2787f1401",
+    name="suspicious_memory_write_to_a_remote_process",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="33270c59-e034-4e5b-accb-b6a23681a0d3", name="Suspicious Memory Write to a Remote Process")
+    ],
+    techniques=['T1055'],
+    sample_hash="84499164a4848a100a22361f38d36ddaea66d01d2e68580271692f9a6fc2a570",
+)

--- a/cortado/rtas/suspicious_netsupport_execution.py
+++ b/cortado/rtas/suspicious_netsupport_execution.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="61631236-50c4-4c93-af2e-cf5f57e4f1af",
+    name="suspicious_netsupport_execution",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="ad53a366-161a-4fa7-a75a-cc00658a767f", name="Suspicious NetSupport Execution")
+    ],
+    techniques=['T1219'],
+    sample_hash="123bb52151b701d54695fb9ff3aeebee55542b71b49051f34dc2808ae5e59f17",
+)

--- a/cortado/rtas/suspicious_ntdll_memory_write.py
+++ b/cortado/rtas/suspicious_ntdll_memory_write.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="fbf21749-9df3-41a3-b0f6-110ed08e036e",
+    name="suspicious_ntdll_memory_write",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="7a23d763-4904-40f9-8169-0c49af65ad30", name="Suspicious NTDLL Memory Write")
+    ],
+    techniques=['T1055'],
+    sample_hash="9f932b464d9cdf2675536a0d392210acdd14987ad018aea73ac34214a7a78ce4",
+)

--- a/cortado/rtas/suspicious_null_terminated_call_stack.py
+++ b/cortado/rtas/suspicious_null_terminated_call_stack.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="280dd2ab-7d13-4ec8-960c-cb5b7ba15277",
+    name="suspicious_null_terminated_call_stack",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="a4684714-f605-4944-98de-e593246faf15", name="Suspicious Null Terminated Call Stack")
+    ],
+    techniques=['T1036', 'T1055'],
+    sample_hash="966a6c9fd83512c580dfc9f8cf666361ba6f7491d296e707a29c4780e5825f3f",
+)

--- a/cortado/rtas/suspicious_powershell_base64_decoding.py
+++ b/cortado/rtas/suspicious_powershell_base64_decoding.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="fd562890-7835-4621-a768-5f9b2d6e1fbf",
+    name="suspicious_powershell_base64_decoding",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="08fa5da1-81af-413d-a960-f7e489c75cfb", name="Suspicious PowerShell Base64 Decoding")
+    ],
+    techniques=['T1059', 'T1059.001'],
+    sample_hash="3b17ec4b7c935487cbfea83e9361dafc0605dde1bca7c8acb9532320d871d345",
+)

--- a/cortado/rtas/suspicious_powershell_script_with_dotnet_reflection.py
+++ b/cortado/rtas/suspicious_powershell_script_with_dotnet_reflection.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="53530324-7735-4702-886b-e056d0c1c118",
+    name="suspicious_powershell_script_with_dotnet_reflection",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="dc6caf51-828c-4264-a96f-bcf21ed18762", name="Suspicious PowerShell Script with .NET Reflection")
+    ],
+    techniques=['T1059', 'T1059.001', 'T1620'],
+    sample_hash="370e0cedd9a4f6ab338cfff223f9afce18e1e3b7555558ecfad469279d76573e",
+)

--- a/cortado/rtas/suspicious_remote_memory_allocation.py
+++ b/cortado/rtas/suspicious_remote_memory_allocation.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="3601bdca-7d24-49c5-a272-0337df9359c8",
+    name="suspicious_remote_memory_allocation",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="b2104624-d0e8-4864-8266-605056c6469a", name="Suspicious Remote Memory Allocation")
+    ],
+    techniques=['T1055'],
+    sample_hash="9bba145cc6507236b26e3b1cc0e91e03a4a12299d57573a0679e6c50b7413b06",
+)

--- a/cortado/rtas/suspicious_windows_api_call_from_virtual_disk_or_usb.py
+++ b/cortado/rtas/suspicious_windows_api_call_from_virtual_disk_or_usb.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="32478195-acb6-4e00-b415-7edd0ee14772",
+    name="suspicious_windows_api_call_from_virtual_disk_or_usb",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="9d5f965f-6f77-45df-9733-8707e40d1d71", name="Suspicious Windows API Call from Virtual Disk or USB")
+    ],
+    techniques=['T1055'],
+    sample_hash="272ccc3ddefa67f5069fb20a2aaf5f8113239c3fccd8e02bb62d9574143de59d",
+)

--- a/cortado/rtas/suspicious_windows_api_call_via_direct_syscall.py
+++ b/cortado/rtas/suspicious_windows_api_call_via_direct_syscall.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="23606530-6eda-4a3d-b4b5-9796ec767619",
+    name="suspicious_windows_api_call_via_direct_syscall",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="fe44381a-435c-4e19-ad89-40ac3750f514", name="Suspicious Windows API Call via Direct Syscall")
+    ],
+    techniques=['T1055'],
+    sample_hash="23f6f5fcea5cb6e919ab5480bccd06d1c863a1f688124d4ee8e27349cc86ae69",
+)

--- a/cortado/rtas/suspicious_windows_api_call_via_rop_gadgets_v2.py
+++ b/cortado/rtas/suspicious_windows_api_call_via_rop_gadgets_v2.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="c4453f69-3717-4ba6-9dff-d61d84223cf6",
+    name="suspicious_windows_api_call_via_rop_gadgets_v2",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="9bc5d4cd-5748-4425-a4f3-7a704a11029d", name="Suspicious Windows API Call via ROP Gadgets v2")
+    ],
+    techniques=['T1055'],
+    sample_hash="b21ab459e9dc1ce72ce5e54d7bc2768da44d6db99894ee29714495382280824a",
+)

--- a/cortado/rtas/suspicious_windows_component_object_model_via_dllhost.py
+++ b/cortado/rtas/suspicious_windows_component_object_model_via_dllhost.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="105c5a12-b2bb-4379-9b92-605779cbadf8",
+    name="suspicious_windows_component_object_model_via_dllhost",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="f678ec9a-c348-485c-ac9e-84b0923ff5f5", name="Suspicious Windows Component Object Model via DLLHOST")
+    ],
+    techniques=['T1559', 'T1559.001', 'T1059', 'T1059.005', 'T1059.007', 'T1059.001', 'T1218', 'T1218.011', 'T1218.010', 'T1218.005'],
+    sample_hash="66524529b7f3e73a721288b900414fe867974a9475887acc40a95275f4d0304a",
+)

--- a/cortado/rtas/suspicious_windows_defender_registry_modification.py
+++ b/cortado/rtas/suspicious_windows_defender_registry_modification.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="81874d86-b586-4c67-9d33-04f0f4b7e028",
+    name="suspicious_windows_defender_registry_modification",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="56751d32-cded-41ad-a273-e6860820c4c3", name="Suspicious Windows Defender Registry Modification")
+    ],
+    techniques=['T1562', 'T1562.001', 'T1112'],
+    sample_hash="0ad4c1b5018e8b639a26c8eca1415dffcd4f828fa82a65bf90955f1925831f64",
+)

--- a/cortado/rtas/suspicious_windows_ldap_image_load.py
+++ b/cortado/rtas/suspicious_windows_ldap_image_load.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="24c3ec30-36fd-4723-9371-3f7318278fa8",
+    name="suspicious_windows_ldap_image_load",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="21daeeb2-fb66-432e-9ca4-92e35f2c154c", name="Suspicious Windows LDAP Image Load")
+    ],
+    techniques=[],
+    sample_hash="534b8130a00712c5ecc8a0bfd19c89657c69d519d2fa02e889bc9ba415732cd6",
+)

--- a/cortado/rtas/suspicious_wmi_library_load.py
+++ b/cortado/rtas/suspicious_wmi_library_load.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="647641b5-a371-4d3f-b1df-3864f835face",
+    name="suspicious_wmi_library_load",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="3cd302aa-098b-4da6-bf20-8d37efe5f861", name="Suspicious WMI Library Load")
+    ],
+    techniques=['T1047'],
+    sample_hash="ca418ccff111b4ce22e4d4c67669ecb8fa3e03d6113d6ff21f3e580bbc994c0d",
+)

--- a/cortado/rtas/unbacked_shellcode_from_unsigned_module.py
+++ b/cortado/rtas/unbacked_shellcode_from_unsigned_module.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="c9dc4331-5ef7-4d7b-a109-7364600c1947",
+    name="unbacked_shellcode_from_unsigned_module",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="99d3049e-f4af-46a7-9406-33482955bec9", name="Unbacked Shellcode from Unsigned Module")
+    ],
+    techniques=['T1055'],
+    sample_hash="903e9205b7c364adb9fe13f85d0029b02cc306bf815275ed4988238654447734",
+)

--- a/cortado/rtas/unusual_windows_system_service_disabled.py
+++ b/cortado/rtas/unusual_windows_system_service_disabled.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="b4245c29-ed9a-4059-a145-4a1303ff2b04",
+    name="unusual_windows_system_service_disabled",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="7c44cfc6-d336-400e-9cc1-2417dfb5c00a", name="Unusual Windows System Service Disabled")
+    ],
+    techniques=['T1112', 'T1562', 'T1562.001'],
+    sample_hash="1250ba6f25fd60077f698a2617c15f89d58c1867339bfd9ee8ab19ce9943304b",
+)

--- a/cortado/rtas/virtualprotect_via_indirect_random_syscall.py
+++ b/cortado/rtas/virtualprotect_via_indirect_random_syscall.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="d50d61c8-9e1c-4afa-b281-0f87ecf38b64",
+    name="virtualprotect_via_indirect_random_syscall",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="2cb8bc8c-8eb7-418e-bb94-016460f8c6e1", name="VirtualProtect via Indirect Random Syscall")
+    ],
+    techniques=['T1055', 'T1036'],
+    sample_hash="670a5d207b3fb79701916bc3a1a25a18b48daba0171b49b6675d3174cff11f43",
+)

--- a/cortado/rtas/windows_defender_exclusions_via_wmi.py
+++ b/cortado/rtas/windows_defender_exclusions_via_wmi.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="a2047077-2333-4a2d-8d22-49768c8ae12a",
+    name="windows_defender_exclusions_via_wmi",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="73310ee3-5e48-4680-b7c5-c096813c7f03", name="Windows Defender Exclusions via WMI")
+    ],
+    techniques=['T1562', 'T1562.001', 'T1047'],
+    sample_hash="a8ad0cb7c6c4d332bc50ca8af649af8877555a79e0d4d1df3cad1ea68acd26fb",
+)

--- a/cortado/rtas/writeprocessmemory_via_indirect_random_syscall.py
+++ b/cortado/rtas/writeprocessmemory_via_indirect_random_syscall.py
@@ -1,0 +1,17 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from . import OSType, RuleMetadata, register_hash_rta
+
+register_hash_rta(
+    id="764c20fb-2c17-4e66-9806-033ca78b4af4",
+    name="writeprocessmemory_via_indirect_random_syscall",
+    platforms=[OSType.WINDOWS],
+    endpoint_rules=[
+        RuleMetadata(id="20106fed-9cb6-41ca-8ca2-ebf55da5fa18", name="WriteProcessMemory via Indirect Random Syscall")
+    ],
+    techniques=['T1055', 'T1036'],
+    sample_hash="6c4a8bd310ce4f1146d84ca455a560fd082e7d22d8b8c772cef5ce89f68e3191",
+)


### PR DESCRIPTION
## Summary

This PR adds a batch of hash based RTAs for various different Windows rules from hashes examined in March 2025.

Note: There are a few RTAs that do not have Techniques populated as the action taken by the malware at the time was considered too broad to fall into a specific technique and only has a tactic. 