### PR TITLE
fix: Cortado wheel file is missing binaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,5 @@ venvPath = "."
 venv = ".venv"
 
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
-build-backend = "setuptools.build_meta"
-
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The `tool.poetry.scripts` binary definitions in `pyproject.toml` stopped being installed in the newest builds of cortado (both the official release and building it from the repo locally).  I dug around a bit and tried the changes in this branch to fix it and it seems to have corrected the issue.

There very well may be a better way to fix the issue, but I wanted to propose the PR so we can discuss it and adjust as necessary.