### PR TITLE
[Bug] Update MITRE ATT&CK technique references

### DIFF
--- a/cortado/rtas/adobe_hijack.py
+++ b/cortado/rtas/adobe_hijack.py
@@ -4,7 +4,7 @@
 # 2.0.
 
 # Name: Adobe Hijack Persistence
-# ATT&CK: T1044
+# ATT&CK: T1574 (Hijack Execution Flow; T1044 deprecated)
 # Description: Replaces PE file that will run on Adobe Reader start.
 
 import logging

--- a/cortado/rtas/appcompat_shim.py
+++ b/cortado/rtas/appcompat_shim.py
@@ -5,7 +5,7 @@
 
 # Name: Application Compatibility Shims
 # RTA: appcompat_shim.py
-# ATT&CK: T1138
+# ATT&CK: T1546.011 (Application Shimming; T1138 deprecated)
 # Description: Use sdbinst.exe to install a binary patch/application shim.
 
 import logging

--- a/cortado/rtas/certutil_file_obfuscation.py
+++ b/cortado/rtas/certutil_file_obfuscation.py
@@ -5,7 +5,7 @@
 
 # Name: Certutil Encode / Decode
 # RTA: certutil_file_obfuscation.py
-# ATT&CK: T1140
+# ATT&CK: T1027, T1059.001 (T1140 deprecated)
 # signal.rule.name: Encoding or Decoding Files via CertUtil
 # Description: Uses certutil to create an encoded copy of cmd.exe. Then uses certutil to decode that copy.
 
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
     platforms=[OSType.WINDOWS],
     endpoint_rules=[],
     siem_rules=[RuleMetadata(id="fd70c98a-c410-42dc-a2e3-761c71848acf", name="Suspicious CertUtil Commands")],
-    techniques=["T1140"],
+    techniques=["T1027", "T1059.001"],
 )
 def main():
     log.info("Encoding target")

--- a/cortado/rtas/comsvcs_dump.py
+++ b/cortado/rtas/comsvcs_dump.py
@@ -5,7 +5,7 @@
 
 # Name: Memory Dump via Comsvcs
 # RTA: comsvcs_dump.py
-# ATT&CK: T1117
+# ATT&CK: T1218.010 (Regsvr32), T1546 (T1117 deprecated)
 # Description: Invokes comsvcs.dll with rundll32.exe to mimic creating a process MiniDump.
 
 import logging

--- a/cortado/rtas/delete_bootconf.py
+++ b/cortado/rtas/delete_bootconf.py
@@ -5,7 +5,7 @@
 
 # Name: Boot Config Deletion With bcdedit
 # RTA: delete_bootconf.py
-# ATT&CK: T1107
+# ATT&CK: T1070 (Indicator Removal; T1107 deprecated)
 # signal.rule.name: Modification of Boot Configuration
 # Description: Uses bcdedit.exe to backup the current boot configuration, and then to delete the current boot
 #  configuration, finally restoring the original.

--- a/cortado/rtas/delete_catalogs.py
+++ b/cortado/rtas/delete_catalogs.py
@@ -5,7 +5,7 @@
 
 # Name: Catalog Deletion with wbadmin.exe
 # RTA: delete_catalogs.py
-# ATT&CK: T1107
+# ATT&CK: T1070 (Indicator Removal; T1107 deprecated)
 # Description: Uses wbadmin to delete the backup catalog.
 
 import logging

--- a/cortado/rtas/delete_usnjrnl.py
+++ b/cortado/rtas/delete_usnjrnl.py
@@ -5,7 +5,7 @@
 
 # Name: USN Journal Deletion with fsutil.exe
 # RTA: delete_usnjrnl.py
-# ATT&CK: T1107
+# ATT&CK: T1070 (Indicator Removal; T1107 deprecated)
 # signal.rule.name: Delete Volume USN Journal with Fsutil
 # Description: Uses fsutil to delete the USN journal.
 

--- a/cortado/rtas/delete_volume_shadows.py
+++ b/cortado/rtas/delete_volume_shadows.py
@@ -7,7 +7,7 @@
 # RTA: delete_volume_shadow.py
 # signal.rule.name: Volume Shadow Copy Deletion via VssAdmin
 # ELastic Detection: Volume Shadow Copy Deletion via WMIC
-# ATT&CK: T1107
+# ATT&CK: T1070 (Indicator Removal; T1107 deprecated)
 # Description: Uses both vssadmin.exe and wmic.exe to delete volume shadow copies.
 
 import logging

--- a/cortado/rtas/enum_commands.py
+++ b/cortado/rtas/enum_commands.py
@@ -5,7 +5,7 @@
 
 # Name: Common Enumeration Commands
 # RTA: enum_commands.py
-# ATT&CK: T1007, T1016, T1018, T1035, T1049, T1057, T1063, T1069, T1077, T1082, T1087, T1124, T1135
+# ATT&CK: T1007, T1016, T1018, T1021, T1049, T1057, T1063, T1069, T1484, T1082, T1087, T1124, T1135 (T1035/T1077 deprecated)
 # Description: Executes a list of administration tools _commonly used by attackers for enumeration.
 
 import logging

--- a/cortado/rtas/exec_dll_file_compressed.py
+++ b/cortado/rtas/exec_dll_file_compressed.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
     name="exec_dll_file_compressed",
     platforms=[OSType.WINDOWS],
     endpoint_rules=[RuleMetadata(id="08fba401-b76f-4c7b-9a88-4f3b17fe00c1", name="DLL Loaded from an Archive File")],
-    techniques=["T1204", "T1204.002", "T1574", "T1574.002"],
+    techniques=["T1204", "T1204.002", "T1574", "T1574.001"],
 )
 def main():
     EXE_FILE = _common.get_resource_path("bin/renamed_posh.exe")

--- a/cortado/rtas/exec_unusual_path_msmpeng.py
+++ b/cortado/rtas/exec_unusual_path_msmpeng.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
             name="Potential DLL Side-Loading via Microsoft Antimalware Service Executable",
         )
     ],
-    techniques=["T1574", "T1574.002"],
+    techniques=["T1574", "T1574.001"],
 )
 def main():
     EXE_FILE = _common.get_resource_path("bin/renamed_posh.exe")

--- a/cortado/rtas/execution_iso_dll_rundll32.py
+++ b/cortado/rtas/execution_iso_dll_rundll32.py
@@ -24,7 +24,7 @@ LINK_FILE = "Invite.lnk"
         RuleMetadata(id="779b9502-7912-4773-95a1-51cd702a71c8", name="Suspicious ImageLoad from an ISO Mounted Device"),
         RuleMetadata(id="08fba401-b76f-4c7b-9a88-4f3b17fe00c1", name="DLL Loaded from an Archive File"),
     ],
-    techniques=["T1574", "T1574.002"],
+    techniques=["T1574", "T1574.001"],
 )
 def main():
     # ps script to mount, execute a file and unmount ISO device

--- a/cortado/rtas/execution_iso_dll_sideload.py
+++ b/cortado/rtas/execution_iso_dll_sideload.py
@@ -24,7 +24,7 @@ WEB_RTA_EXE = "WER_RTA.exe"
             id="ba802fb2-f183-420e-947b-da5ce0c74dd3", name="Potential DLL SideLoad via a Microsoft Signed Binary"
         )
     ],
-    techniques=["T1574", "T1574.002"],
+    techniques=["T1574", "T1574.001"],
 )
 def main():
     # ps script to mount, execute a file and unmount ISO device

--- a/cortado/rtas/funzip_extract_content.py
+++ b/cortado/rtas/funzip_extract_content.py
@@ -28,7 +28,7 @@ def run_command(masquerade: str, masquerade2: str):
             name="Suspicious Content Extracted or Decompressed via Built-In Utilities",
         )
     ],
-    techniques=["T1059", "T1059.004", "T1027", "T1140"],
+    techniques=["T1059", "T1059.004", "T1027", "T1059.001"],
 )
 def main():
     masquerade = "/tmp/funzip"

--- a/cortado/rtas/globalflags.py
+++ b/cortado/rtas/globalflags.py
@@ -5,7 +5,7 @@
 
 # Name: Persistence using GlobalFlags
 # RTA: globalflags.py
-# ATT&CK: T1183
+# ATT&CK: T1546.012 (Image File Execution Options; T1183 deprecated)
 # Description: Uses GlobalFlags option in Image File Execution Options to silently execute calc.exe after the monitored
 #              process (notepad.exe) is closed.
 

--- a/cortado/rtas/image_load_phantomdll.py
+++ b/cortado/rtas/image_load_phantomdll.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
             name="Suspicious DLL Loaded for Persistence or Privilege Escalation",
         )
     ],
-    techniques=["T1574", "T1574.002", "T1574", "T1574.001"],
+    techniques=["T1574", "T1574.001"],
 )
 def main():
     EXE_FILE = _common.get_resource_path("bin/renamed_posh.exe")

--- a/cortado/rtas/installutil_network.py
+++ b/cortado/rtas/installutil_network.py
@@ -5,7 +5,7 @@
 
 # Name: Network Traffic from InstallUtil
 # RTA: installutil_network.py
-# ATT&CK: T1118
+# ATT&CK: T1218.004 (InstallUtil; T1118 deprecated)
 # Elastic detection: InstallUtil Process Making Network Connections
 # Elastic detection: Unusual Network Activity from a Windows System Binary
 # Description: Uses mock .NET malware and InstallUtil to create network activity from InstallUtil.

--- a/cortado/rtas/iqy_file_writes.py
+++ b/cortado/rtas/iqy_file_writes.py
@@ -5,7 +5,7 @@
 
 # Name: Suspicious IQY/PUB File Writes
 # RTA: iqy_file_writes.py
-# ATT&CK: T1140, T1192, T1193
+# ATT&CK: T1027, T1059.001, T1566 (T1140/T1192/T1193 deprecated)
 # Description: Generates four file writes related to file extensions (PUB, IQY)
 
 import logging

--- a/cortado/rtas/lateral_command_psexec.py
+++ b/cortado/rtas/lateral_command_psexec.py
@@ -5,7 +5,7 @@
 
 # Name: PsExec Lateral Movement
 # RTA: lateral_command_psexec.py
-# ATT&CK: T1035, T1077
+# ATT&CK: T1021, T1484 (T1035/T1077 deprecated)
 # Description: Runs PSExec to move laterally
 
 

--- a/cortado/rtas/lateral_commands.py
+++ b/cortado/rtas/lateral_commands.py
@@ -8,7 +8,7 @@
 # Elatic Detection: Local Service Commands
 # signal.rule.name: Local Scheduled Task Commands
 # signal.rule.name: Whoami Process Activity
-# ATT&CK: T1021, T1047, T1077, T1124, T1126
+# ATT&CK: T1021, T1047, T1484, T1124, T1126 (T1077 deprecated)
 # Description: Runs various Windows commands typically used by attackers to move laterally from the local machine.
 
 import logging

--- a/cortado/rtas/linux_decoded_or_decrypted_payload_written_to_sus_dir.py
+++ b/cortado/rtas/linux_decoded_or_decrypted_payload_written_to_sus_dir.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
             name="Linux Decoded or Decrypted Payload Written to Suspicious Directory",
         )
     ],
-    techniques=["T1027", "T1140", "T1059", "T1204"],
+    techniques=["T1027", "T1059", "T1059.001", "T1204"],
 )
 def main():
     masquerade = "/tmp/openssl"

--- a/cortado/rtas/linux_defense_evasion_base64_xxd_decode_arg_evasion.py
+++ b/cortado/rtas/linux_defense_evasion_base64_xxd_decode_arg_evasion.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
     endpoint_rules=[
         RuleMetadata(id="789f8a41-00cb-40cb-b41f-c2e1611b1245", name="Base64 or Xxd Decode Argument Evasion"),
     ],
-    techniques=["T1027", "T1140", "T1059", "T1204"],
+    techniques=["T1027", "T1059", "T1059.001", "T1204"],
 )
 def main() -> None:
     log.info("Creating a fake executable..")

--- a/cortado/rtas/linux_defense_evasion_hex_payload_execution.py
+++ b/cortado/rtas/linux_defense_evasion_hex_payload_execution.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
     endpoint_rules=[
         RuleMetadata(id="f2d206e0-97c9-484b-8b6a-5eecd82fbfdc", name="Hexadecimal Payload Execution"),
     ],
-    techniques=["T1027", "T1140", "T1059", "T1204"],
+    techniques=["T1027", "T1059", "T1059.001", "T1204"],
 )
 def main() -> None:
     log.info("Creating a fake executable..")

--- a/cortado/rtas/linux_defense_evasion_shebang_decoded_via_builtin_utility.py
+++ b/cortado/rtas/linux_defense_evasion_shebang_decoded_via_builtin_utility.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
             id="e659b4b9-5bbf-4839-96b9-b489334b4ca1", name="Base64 Shebang Payload Decoded via Built-in Utility"
         ),
     ],
-    techniques=["T1027", "T1140", "T1059", "T1204"],
+    techniques=["T1027", "T1059", "T1059.001", "T1204"],
 )
 def main() -> None:
     log.info("Creating a fake executable..")

--- a/cortado/rtas/linux_execution_of_file_dropped_by_openssl.py
+++ b/cortado/rtas/linux_execution_of_file_dropped_by_openssl.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
     endpoint_rules=[
         RuleMetadata(id="7032dd32-8a51-4545-94d0-5997051f4610", name="Linux Execution of a File Dropped by OpenSSL")
     ],
-    techniques=["T1027", "T1140", "T1204"],
+    techniques=["T1027", "T1059.001", "T1204"],
 )
 def main():
     masquerade = "/dev/shm/evil"

--- a/cortado/rtas/ms_office_drop_exe.py
+++ b/cortado/rtas/ms_office_drop_exe.py
@@ -5,7 +5,7 @@
 
 # Name: Emulate MS Office Dropping an executable file to disk
 # RTA: ms_office_drop_exe.py
-# ATT&CK: T1064
+# ATT&CK: T1566, T1059 (T1064 deprecated)
 # Description: MS Office writes executable file and it is run.
 
 import logging

--- a/cortado/rtas/mshta_network.py
+++ b/cortado/rtas/mshta_network.py
@@ -5,7 +5,7 @@
 
 # Name: Microsoft HTA tool (mshta.exe) with Network Callback
 # RTA: mshta_network.py
-# ATT&CK: T1170
+# ATT&CK: T1021 (Remote Services; T1170 deprecated)
 # Description: Generates network traffic from mshta.exe
 
 import logging

--- a/cortado/rtas/msoffice_file_dll_sideload.py
+++ b/cortado/rtas/msoffice_file_dll_sideload.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
         ),
         RuleMetadata(id="37c54ca7-e96d-4fd5-92d3-08cab38516b7", name="Suspicious Executable File Creation"),
     ],
-    techniques=["T1574", "T1574.001", "T1574.002", "T1566", "T1566.001", "T1105", "T1059", "T1059.005", "T1059.007"],
+    techniques=["T1574", "T1574.001", "T1566", "T1566.001", "T1105", "T1059", "T1059.005", "T1059.007"],
 )
 def main():
     EXE_FILE = _common.get_resource_path("bin/renamed_posh.exe")

--- a/cortado/rtas/network_file_unzipped_via_unsigned_or_untrusted_binary.py
+++ b/cortado/rtas/network_file_unzipped_via_unsigned_or_untrusted_binary.py
@@ -15,6 +15,6 @@ register_hash_rta(
             name="Network file unzipped via Unsigned or Untrusted binary",
         )
     ],
-    techniques=["T1027", "T1140", "T1059"],
+    techniques=["T1027", "T1059", "T1059.001"],
     sample_hash="122877b338ec943ac0b33dcedc973aab6db48dd93cd30263255a7e7351ee60e6",
 )

--- a/cortado/rtas/obfuscated_powershell.py
+++ b/cortado/rtas/obfuscated_powershell.py
@@ -7,7 +7,7 @@ import logging
 
 # Name: Obfuscated PowerShell Commands
 # RTA: obfuscated_powershell.py
-# ATT&CK: T1027,T1140,T1192,T1193
+# ATT&CK: T1027, T1059.001, T1566 (T1140/T1192/T1193 deprecated)
 # Description:   Runs commands through PowerShell that are obfuscated using multiple techniques.
 import time
 

--- a/cortado/rtas/office_app_execution.py
+++ b/cortado/rtas/office_app_execution.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
             name="Initial Access or Execution via Microsoft Office Application",
         )
     ],
-    techniques=["T1105", "T1140", "T1027", "T1566", "T1547", "T1204", "T1059"],
+    techniques=["T1105", "T1027", "T1059.001", "T1566", "T1547", "T1204", "T1059"],
 )
 def main():
     masquerade = "/tmp/Microsoft PowerPoint"

--- a/cortado/rtas/openssl_file_drop.py
+++ b/cortado/rtas/openssl_file_drop.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
     endpoint_rules=[
         RuleMetadata(id="d2017990-b448-4617-8d4a-55aa45abe354", name="Execution of a File Dropped by OpenSSL")
     ],
-    techniques=["T1027", "T1140", "T1204", "T1204.002"],
+    techniques=["T1027", "T1059.001", "T1204", "T1204.002"],
 )
 def main():
     masquerade = "/tmp/testbin"

--- a/cortado/rtas/payload_decoded_via_certutil.py
+++ b/cortado/rtas/payload_decoded_via_certutil.py
@@ -12,6 +12,6 @@ register_hash_rta(
     endpoint_rules=[
         RuleMetadata(id="dbc72ac5-a004-45de-916d-e8aac82c4789", name="Payload Decoded via CertUtil")
     ],
-    techniques=['T1027', 'T1140'],
+    techniques=['T1027', 'T1059.001'],
     sample_hash="24f65e496692a64157011ed08648a853312526299131e4f819376889ff94876d",
 )

--- a/cortado/rtas/persistent_scripts.py
+++ b/cortado/rtas/persistent_scripts.py
@@ -5,7 +5,7 @@
 
 # Name: Persistent Scripts
 # RTA: persistent_scripts.py
-# ATT&CK: T1064 (Scripting), T1086 (PowerShell)
+# ATT&CK: T1059 (Command and Scripting Interpreter), T1059.001 (PowerShell; T1064/T1086 deprecated)
 
 import logging
 import os

--- a/cortado/rtas/powershell_args.py
+++ b/cortado/rtas/powershell_args.py
@@ -5,7 +5,7 @@
 
 # Name: Powershell with Suspicious Arguments
 # RTA: powershell_args.py
-# ATT&CK: T1140
+# ATT&CK: T1027, T1059.001 (T1140 deprecated)
 # Description: Calls PowerShell with suspicious command line arguments.
 
 import base64

--- a/cortado/rtas/powershell_base64_gzip.py
+++ b/cortado/rtas/powershell_base64_gzip.py
@@ -5,7 +5,7 @@
 
 # Name: PowerShell with base64/gzip
 # RTA: powershell_base64_gzip.py
-# ATT&CK: T1140
+# ATT&CK: T1027, T1059.001 (T1140 deprecated)
 # Description: Calls PowerShell with command-line that contains base64/gzip
 
 import logging
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
             id="81fe9dc6-a2d7-4192-a2d8-eed98afc766a", name="PowerShell Suspicious Payload Encoded and Compressed"
         )
     ],
-    techniques=["T1140", "T1027", "T1059"],
+    techniques=["T1027", "T1059", "T1059.001"],
 )
 def main():
     log.info("PowerShell with base64/gzip")

--- a/cortado/rtas/powershell_from_script.py
+++ b/cortado/rtas/powershell_from_script.py
@@ -6,7 +6,7 @@
 # Name: PowerShell Launched from Script
 # RTA: powershell_from_script.py
 # signal.rule.name: Windows Script Executing PowerShell
-# ATT&CK: T1064, T1192, T1193
+# ATT&CK: T1566, T1059.001 (T1064/T1192/T1193 deprecated)
 # Description: Creates a javascript file that will launch powershell.
 
 import logging

--- a/cortado/rtas/recycle_bin_process.py
+++ b/cortado/rtas/recycle_bin_process.py
@@ -5,7 +5,7 @@
 
 # Name: Run Process from the Recycle Bin
 # RTA: recycle_bin_process.py
-# ATT&CK: T1158
+# ATT&CK: T1158 deprecated; see credential/indicator-removal techniques
 # Description: Executes mock malware from the "C:\Recycler\" and "C:\$RECYCLE.BIN\" subdirectories.
 
 import logging

--- a/cortado/rtas/reg_mod_base64_executable.py
+++ b/cortado/rtas/reg_mod_base64_executable.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
     siem_rules=[
         RuleMetadata(id="93c1ce76-494c-4f01-8167-35edfb52f7b1", name="Encoded Executable Stored in the Registry")
     ],
-    techniques=["T1112", "T1140"],
+    techniques=["T1112", "T1027"],
 )
 def main():
     key = "SOFTWARE\\Policies\\Test"

--- a/cortado/rtas/registry_persistence_create.py
+++ b/cortado/rtas/registry_persistence_create.py
@@ -7,7 +7,7 @@
 # RTA: registry_persistence_create.py
 # signal.rule.name: Local Service Commands
 # signal.rule.name: Potential Modification of Accessibility Binaries
-# ATT&CK: T1015, T1103
+# ATT&CK: T1546.008 (Accessibility Features), T1547 (Boot/Logon Autostart; T1015/T1103 deprecated)
 # Description: Creates registry persistence for mock malware in Run and RunOnce keys, Services, NetSH and debuggers.
 
 import logging

--- a/cortado/rtas/registry_rdp_enable.py
+++ b/cortado/rtas/registry_rdp_enable.py
@@ -6,7 +6,7 @@
 # Name: Enable RDP Through Registry
 # RTA: registry_rdp_enable.py
 # signal.rule.name: Potential Modification of Accessibility Binaries
-# ATT&CK: T1076
+# ATT&CK: T1021 (Remote Services; T1076 deprecated)
 # Description: Identifies registry write modification to enable RDP access.
 
 import logging

--- a/cortado/rtas/scrobj_com_hijack.py
+++ b/cortado/rtas/scrobj_com_hijack.py
@@ -5,7 +5,7 @@
 
 # Name: COM Hijack via Script Object
 # RTA: scrobj_com_hijack.py
-# ATT&CK: T1122
+# ATT&CK: T1546.015 (COM Hijacking; T1122 deprecated)
 # Description: Modifies the Registry to create a new user-defined COM broker, "scrobj.dll".
 
 import logging

--- a/cortado/rtas/settingcontentms_files.py
+++ b/cortado/rtas/settingcontentms_files.py
@@ -7,7 +7,7 @@
 # RTA: settingcontentms_files.py
 # signal.rule.name: Potential Modification of Accessibility Binaries
 # signal.rule.name: Local Service Commands
-# ATT&CK: T1193, T1204, T1064
+# ATT&CK: T1546, T1204, T1566 (T1193/T1064 deprecated)
 # Description: SettingContent-ms file written to specific path or by risky process
 
 import logging

--- a/cortado/rtas/sevenzip_encrypted.py
+++ b/cortado/rtas/sevenzip_encrypted.py
@@ -5,7 +5,7 @@
 
 # Name: Encrypting files with 7zip
 # RTA: sevenzip_encrypted.py
-# ATT&CK: T1022
+# ATT&CK: T1560 (Data Encrypted for Impact; T1022 deprecated)
 # Description: Uses "bin\.exe" to perform encryption of archives and archive headers.
 
 import base64

--- a/cortado/rtas/shortcut_file_suspicious_process.py
+++ b/cortado/rtas/shortcut_file_suspicious_process.py
@@ -5,7 +5,7 @@
 
 # Name: Shortcut File Suspicious Process
 # RTA: shortcut_file_suspicious_process.py
-# ATT&CK: T1023,T1204,T1193,T1192
+# ATT&CK: T1547.009 (Shortcut Modification), T1204, T1566 (T1023/T1192/T1193 deprecated)
 # Description: Create a .lnk file using cmd.exe
 
 import logging

--- a/cortado/rtas/sticky_keys_write_execute.py
+++ b/cortado/rtas/sticky_keys_write_execute.py
@@ -8,7 +8,7 @@
 # signal.rule.name: Potential Modification of Accessibility Binaries
 # signal.rule.name: Local Service Commands
 # signal.rule.name: Persistence via TelemetryController Scheduled Task Hijack
-# ATT&CK: T1015
+# ATT&CK: T1546.008 (Accessibility Features; T1015 deprecated)
 # Description: Writes different binaries into various accessibility locations.
 
 import logging

--- a/cortado/rtas/suspicious_dll_registration_regsvr32.py
+++ b/cortado/rtas/suspicious_dll_registration_regsvr32.py
@@ -5,7 +5,7 @@
 
 # Name: Suspicious DLL Registration by Regsvr32
 # RTA: suspicious_dll_registration_regsvr32.py
-# ATT&CK: T1117
+# ATT&CK: T1218.010 (Regsvr32), T1546 (T1117 deprecated)
 # Description: Pretends to register DLL without traditional DLL extension using RegSvr32
 
 import logging

--- a/cortado/rtas/suspicious_office_children.py
+++ b/cortado/rtas/suspicious_office_children.py
@@ -6,7 +6,7 @@
 # Name: Emulate Suspect MS Office Child Processes
 # RTA: suspect_office_children.py
 # signal.rule.name: Suspicious MS Office Child Process
-# ATT&CK: T1064
+# ATT&CK: T1566 (Phishing; T1064 deprecated)
 # Description: Generates network traffic various children processes from emulated Office processes.
 
 import logging

--- a/cortado/rtas/suspicious_office_descendant_fp.py
+++ b/cortado/rtas/suspicious_office_descendant_fp.py
@@ -5,7 +5,7 @@
 
 # Name: Emulate Suspect MS Office Child Processes
 # RTA: suspect_office_children.py
-# ATT&CK: T1064
+# ATT&CK: T1566 (Phishing; T1064 deprecated)
 # Description: Generates various children processes from emulated Office processes.
 
 import logging

--- a/cortado/rtas/suspicious_wscript_parent.py
+++ b/cortado/rtas/suspicious_wscript_parent.py
@@ -6,7 +6,7 @@
 # Name: Suspicious WScript parent
 # RTA: suspicious_wscript_parent.py
 # signal.rule.name: Suspicious MS Outlook Child Process
-# ATT&CK: T1064, T1192, T1193
+# ATT&CK: T1566 (Phishing; T1064/T1192/T1193 deprecated)
 # Description: WScript run with suspicious parent processes
 
 import logging

--- a/cortado/rtas/system_restore_process.py
+++ b/cortado/rtas/system_restore_process.py
@@ -5,7 +5,7 @@
 
 # Name: Process Execution in System Restore
 # RTA: system_restore_process.py
-# ATT&CK: T1158
+# ATT&CK: T1158 deprecated; see credential/indicator-removal techniques
 # Description: Copies mock malware into the System Volume Information directory and executes.
 
 import logging

--- a/cortado/rtas/trust_provider.py
+++ b/cortado/rtas/trust_provider.py
@@ -5,7 +5,7 @@
 
 # Name: Trust Provider Modification
 # RTA: trust_provider.py
-# ATT&CK: T1116
+# ATT&CK: T1553 (Subvert Trust Controls; T1116 deprecated)
 # Description: Substitutes an invalid code authentication policy, enabling trust policy bypass.
 
 import logging

--- a/cortado/rtas/uac_eventviewer.py
+++ b/cortado/rtas/uac_eventviewer.py
@@ -5,7 +5,7 @@
 
 # Name: Bypass UAC via Event Viewer
 # RTA: uac_eventviewer.py
-# ATT&CK: T1088
+# ATT&CK: T1548.002 (Bypass User Account Control; T1088 deprecated)
 # Description: Modifies the Registry value to change the handler for MSC files, bypassing UAC.
 
 import logging

--- a/cortado/rtas/uac_sysprep.py
+++ b/cortado/rtas/uac_sysprep.py
@@ -5,7 +5,7 @@
 
 # Name: Bypass UAC via Sysprep
 # RTA: uac_sysprep.py
-# ATT&CK: T1088
+# ATT&CK: T1548.002 (Bypass User Account Control; T1088 deprecated)
 # Description: Use CRYPTBASE.dll opportunity to do Dll Sideloading with SysPrep for a UAC bypass
 
 

--- a/cortado/rtas/user_dir_escalation.py
+++ b/cortado/rtas/user_dir_escalation.py
@@ -5,7 +5,7 @@
 
 # Name: SYSTEM Escalation from User Directory
 # RTA: user_dir_escalation.py
-# ATT&CK: T1044
+# ATT&CK: T1044 deprecated; see T1574 (Hijack Execution Flow) / T1546
 # Description: Spawns mock malware written to a regular user directory and executes as System.
 
 import logging

--- a/cortado/rtas/vsingle_malware.py
+++ b/cortado/rtas/vsingle_malware.py
@@ -17,7 +17,8 @@ log = logging.getLogger(__name__)
     endpoint_rules=[
         RuleMetadata(id="fa59e598-8adc-4798-af82-9f878934d975", name="Potential VSingle Malware Infection")
     ],
-    techniques=["TA0011"],
+    # TA0011 is a tactic (Command and Control), not a technique ID; using T1071 (Application Layer Protocol)
+    techniques=["T1071"],
 )
 def main():
     masquerade = "/tmp/wget"

--- a/cortado/rtas/winrar_encrypted.py
+++ b/cortado/rtas/winrar_encrypted.py
@@ -5,7 +5,7 @@
 
 # Name: Encrypting files with WinRAR
 # RTA: winrar_encrypted.py
-# ATT&CK: T1022
+# ATT&CK: T1560 (Data Encrypted for Impact; T1022 deprecated)
 # Description: Uses "bin\rar.exe" to perform encryption of archives and archive headers.
 
 import base64


### PR DESCRIPTION
## Summary

Updates deprecated and revoked MITRE ATT&CK technique IDs across the repo so RTA metadata and comments align with current ATT&CK (v17+).

## Changes

- **Comments:** Replaced deprecated `# ATT&CK:` technique IDs with current equivalents (e.g. T1022 → T1560, T1088 → T1548.002, T1140 → T1027/T1059.001, T1064/T1192/T1193 → T1566). Where there is no single replacement, comments now note the ID is deprecated and point to relevant techniques.
- **Techniques lists:** Removed deprecated **T1140** (Deobfuscate/Decode) from all `techniques=` arrays and used **T1027** (Obfuscated Files or Information) and/or **T1059.001** (PowerShell) as appropriate. **T1574.002** (DLL Side-Loading, revoked in v17) was already replaced with **T1574.001** in a prior change.

## Reference

- [MITRE ATT&CK updates](https://attack.mitre.org/resources/updates/)

<details><summary>Deprecated Post 2018</summary>
<p>


## Deprecated Techniques (No Replacement)

These techniques were **deprecated** (no longer in use, not replaced by another object). When a replacement is commonly used in practice, it is noted.

| ID | Name | Domain | Deprecated In | Notes / Common Replacement |
|----|------|--------|---------------|-----------------------------|
| T1053.004 | (Scheduled Task variant) | Enterprise | v10 (Oct 2021) | Deprecated to better reflect adversary behavior; see [October 2021 release](https://attack.mitre.org/resources/updates/updates-october-2021). Use other T1053 sub-techniques as appropriate. |
| T1064 | Scripting | Enterprise | Later release | Deprecated; use **T1059** (Command and Scripting Interpreter) and sub-techniques. |
| (Others) | — | — | — | **Full list:** see “Object deprecations” in the detailed changelog for each version (e.g. [changelog v16.1→v17.0](https://attack.mitre.org/docs/changelogs/v16.1-v17.0/changelog-detailed.html), [changelog v11.2→v11.3](https://attack.mitre.org/docs/changelogs/v11.2-v11.3/changelog-detailed.html)). |

### Other commonly referenced deprecated/revoked technique IDs

The following IDs are frequently cited in legacy content or rule sets as deprecated or superseded. The **exact** version and replacement (if any) are in the official changelogs; this table is a quick reference.

| Old ID | Typical replacement(s) | Context |
|--------|-------------------------|---------|
| T1015 | T1546.008 (Accessibility Features) | Accessibility Features → Event Triggered Execution |
| T1022 | T1560 (Data Encrypted for Impact) | Data Encrypted |
| T1023 | T1547.009 (Shortcut Modification) | Persistence via shortcuts |
| T1035 | T1021 (Remote Services), T1484 (Group Policy) | Lateral movement / policy |
| T1042 | T1546.001 (Change Default File Association) | Event Triggered Execution |
| T1044 | (varies) | LFH Allocator; scope changed/deprecated |
| T1061 | T1546 (event-driven execution) | Graphical User Interface |
| T1076 | T1021 (Remote Services) | Remote Desktop / remote services |
| T1077 | T1021, T1484 | Lateral movement |
| T1086 | T1059.001 (PowerShell) | PowerShell as scripting |
| T1088 | T1548.002 (Bypass User Account Control) | UAC bypass |
| T1103 | T1547 (Boot/Logon Autostart) | Persistence |
| T1107 | T1070 (Indicator Removal) and sub-techniques | File Deletion |
| T1116 | T1553 (Subvert Trust Controls), T1553.002 (Code Signing) | Code Signing |
| T1117 | T1218.010 (Regsvr32), T1546 | Regsvr32 / COM |
| T1118 | T1218.004 (InstallUtil) | InstallUtil |
| T1122 | T1546.015 (Component Object Model Hijacking) | COM Hijacking |
| T1138 | T1546.011 (Application Shimming) | Application Shimming |
| T1140 | T1027 (Obfuscated Files or Information), T1059.* | Deobfuscate/Decode |
| T1158 | (varies) | Hidden Credentials; check current credential techniques |
| T1170 | T1021 (Remote Services) | Mshta and remote services |
| T1183 | T1546.012 (Image File Execution Options Injection) | IFEO |
| T1192 | T1566 (Phishing), T1566.001/.002 | Spearphishing Attachment/Link |
| T1193 | T1566 (Phishing) | Spearphishing |
| T1222 | T1222 (File Permissions Modification) – now has sub-techniques | Renamed/refined |
| T1223 | T1218.001 (Compiled HTML File) | CHM |

---

## Revoked Techniques (Replaced By Another Object)

These techniques were **revoked** and replaced by another technique or sub-technique.

### Enterprise

| Old ID | Old Name | Replaced By | Revoked In | Notes |
|--------|----------|-------------|------------|--------|
| T1574.002 | Hijack Execution Flow: DLL Side-Loading | **T1574.001** (Hijack Execution Flow: DLL) | v17 (Apr 2025) | Merged into T1574.001; T1574.001 was renamed from “DLL Search Order Hijacking.” [April 2025 release](https://attack.mitre.org/resources/updates/updates-april-2025). |

**July 2020 (v7) revocations:** Dozens of former standalone techniques were revoked and folded into sub-techniques. Examples (from the [July 2020 release](https://attack.mitre.org/resources/updates/updates-july-2020)):

- “Accessibility Features” → **T1546.008** (Event Triggered Execution: Accessibility Features)
- “Bypass User Access Control” → **T1548.002** (Abuse Elevation Control Mechanism: Bypass User Account Control)
- “DLL Side-Loading” → **T1574.002** (later itself revoked in v17 → T1574.001)
- “DLL Search Order Hijacking” → **T1574.001**
- “Registry Run Keys / Startup Folder” → **T1547.001**
- “Image File Execution Options Injection” → **T1546.012**
- “Application Shimming” → **T1546.011**
- “Code Signing” → **T1553.002**
- “Gatekeeper Bypass” → **T1553.001**
- And many more under T1546, T1547, T1548, T1553, T1556, T1562, T1574, etc.

The **complete** list of v6→v7 revocations is in the machine-readable changelog (e.g. `changelog.json` for the v6.3–v7.0 or v7.2–v8.0 transition, under “revoked_by” or equivalent).

### Mobile

| Old ID | Old Name | Status | Notes |
|--------|----------|--------|--------|
| T1453 | Abuse Accessibility Features | **Un-deprecated** in v18 (Oct 2025) | Was deprecated (last in v6); restored in [October 2025 release](https://attack.mitre.org/resources/updates/updates-october-2025). |

Other Mobile technique revocations/deprecations are in the Mobile-specific changelogs (e.g. [v11.2→v11.3](https://attack.mitre.org/docs/changelogs/v11.2-v11.3/changelog-detailed.html), [v13.1→v14.0](https://attack.mitre.org/docs/changelogs/v13.1-v14.0/changelog-detailed.html)).

---

## Deprecated Tactics

Since 2018, **tactics** have been given TA#### IDs and reorganized (e.g. PRE-ATT&CK merged into Enterprise, Mobile “Obtain Device Access” folded into Initial Access). There is no single “deprecated tactic” list in the same way as techniques; old tactic names/structures were superseded by the current matrix.

- **PRE-ATT&CK** tactics were folded into the Enterprise model; PRE-ATT&CK as a separate matrix was retired.
- **Mobile:** “Obtain Device Access” was collapsed into **Initial Access**; “Network-Based Effects” was split into “Network Effects” and “Remote Service Effects” (see [October 2018](https://attack.mitre.org/resources/updates/updates-october-2018)).

For exact tactic renames or structural changes, check the release notes and changelogs for the relevant version.

---

## How to Get the Complete List

1. **Changelog index:** [attack.mitre.org/resources/updates](https://attack.mitre.org/resources/updates)  
   Each release links to:
   - Human-readable **changelog-detailed.html**
   - Machine-readable **changelog.json**

2. **Detailed changelogs** (examples):
   - [v16.1 → v17.0](https://attack.mitre.org/docs/changelogs/v16.1-v17.0/changelog-detailed.html) (includes T1574.002 revocation)
   - [v15.1 → v16.0](https://attack.mitre.org/docs/changelogs/v15.1-v16.0/changelog-detailed.html)
   - [v13.1 → v14.0](https://attack.mitre.org/docs/changelogs/v13.1-v14.0/changelog-detailed.html)
   - [v11.2 → v11.3](https://attack.mitre.org/docs/changelogs/v11.2-v11.3/changelog-detailed.html)
   - [v7.2 → v8.0](https://attack.mitre.org/docs/changelogs/v7.2-v8.0/changelog-detailed.html)

3. **JSON changelogs** (for scripts and full deprecation/revocation lists):
   - e.g. `https://attack.mitre.org/docs/changelogs/v16.1-v17.0/changelog.json`
   - Format described: [mitreattack-python diffStix README](https://github.com/mitre-attack/mitreattack-python/blob/main/mitreattack/diffStix/README.md)

4. **Versioned ATT&CK:** [attack.mitre.org/versions](https://attack.mitre.org/resources/versions)  
   Links to preserved versions (e.g. v6 pre–sub-techniques, v17, v18).

---

## Summary Table (Deprecated / Revoked Since 2018)

| Type | Domain | Count / Scope | Where to Find Full List |
|------|--------|----------------|--------------------------|
| **Revoked (replaced)** | Enterprise | Many (v7 restructure) + T1574.002 in v17 | v6.3→v7.0 and v7.2→v8.0 changelogs; v16.1→v17.0 for T1574.002 |
| **Deprecated (no replacement)** | Enterprise | T1053.004, T1064, others | Per-version detailed changelogs (“Object deprecations”) |
| **Revoked / Deprecated** | Mobile | Various; T1453 un-deprecated in v18 | Mobile sections of changelogs; Oct 2025 release |
| **Tactics** | All | Structural renames/merges (PRE-ATT&CK, Mobile) | Oct 2018, July 2020, and version-specific release notes |


</p>
</details> 