### PR TITLE
chore: add explicit permissions block

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Check if member of elastic org
         uses: actions/github-script@v6


### PR DESCRIPTION
## Summary

Adds a small update to add an explicit permissions block for our community gh action workflow.