### PR TITLE
[FR] Switch to Ephemeral tokens for the Community Workflow

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -13,12 +13,20 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      id-token: write
     steps:
+      - name: Fetch ephemeral GitHub token
+        id: fetch-ephemeral-token
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.3
+        with:
+          vault-instance: "ci-prod"
+          vault-role: "token-policy-4a57efea1929"
+
       - name: Check if member of elastic org
         uses: actions/github-script@v6
         id: membership
         with:
-          github-token: ${{ secrets.READ_CORTADO_ELASTIC_ORG_TOKEN }}
+          github-token: ${{ steps.fetch-ephemeral-token.outputs.token }}
           result-encoding: string
           script: |
 


### PR DESCRIPTION
Related Issues:

Related to https://github.com/elastic/ia-trade-team/issues/960

## Summary

Updates `.github/workflows/community.yml` to fetch a short-lived GitHub token via OIDC instead of using the long-lived
`READ_CORTADO_ELASTIC_ORG_TOKEN` repository secret.

This follows the same pattern applied to the non-detection-rules workflows in
[elastic/detection-rules#6524](https://github.com/elastic/detection-rules/pull/6524).

